### PR TITLE
Move publish tf from scuttle gazebo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,6 @@ project(scuttle_bringup)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  scuttle_model
-  scuttle_driver
-  scuttle_navigation
   roscpp
   rospy
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ project(scuttle_bringup)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  scuttle_description
+  scuttle_model
+  scuttle_driver
+  scuttle_navigation
   roscpp
   rospy
 )

--- a/launch/base.launch
+++ b/launch/base.launch
@@ -1,27 +1,60 @@
 <launch>
-	<arg name="is_physical" default="true"/>
-	<param name="enable_tf_publish" value="true"/>
-	<param name="enable_joint_state_publish" value="true"/>
+    <arg name="is_physical" default="true"/>
+    <param name="enable_tf_publish" value="true"/>
+    <param name="enable_joint_state_publish" value="true"/>
 
-	<group unless="$(arg is_physical)">
-		<param name ="/use_sim_time" value="true"/>
+    <!--
+        Publish the robot model to the parameter server so that other nodes can determine what
+        the different joints of the robot are.
+    -->
+    <param
+        name="robot_description"
+        command="$(find xacro)/xacro $(find scuttle_description)/urdf/scuttle.xacro" />
 
-		<!-- Don't need a lidar here because the gazebo files already have that included -->
-	</group>
+    <group unless="$(arg is_physical)">
+        <param name ="/use_sim_time" value="true"/>
 
-	<group if="$(arg is_physical)">
-		<param name ="/use_sim_time" value="false"/>
-		<node name="scuttle_driver" pkg="scuttle_driver" type="scuttle_driver.py" output="screen"/>
-	</group>
+        <!-- Don't need a lidar here because the gazebo files already have that included -->
+    </group>
 
-	<!--
-		We don't include the SLAM node here because gmapping puts out a lot of logs to the console that can't be
-		silenced. So instead we run that as a stand-alone node. That way gmapping won't polute the navigation logs
-	-->
+    <group if="$(arg is_physical)">
+        <param name ="/use_sim_time" value="false"/>
+        <node name="scuttle_driver" pkg="scuttle_driver" type="scuttle_driver.py" output="screen"/>
+    </group>
 
-	<include file="$(find scuttle_navigation)/launch/scuttle_navigation.launch">
-		<arg name="map_file" value="$(find scuttle_navigation)/maps/map.yaml"/>
-		<arg name="move_forward_only" value="false"/>
-		<arg name="is_physical" value="$(arg is_physical)"/>
-	</include>
+    <!--
+        We always need to publish joint and robot states. So we do that here.
+    -->
+    <!--
+        First publish the joint state for the robot. The joint_state_publisher (see: http://wiki.ros.org/joint_state_publisher)
+        picks up the robot description (provided by scuttle_description and scuttle_model) from the
+        parameter server via the `robot_description` parameter.
+        The joint_state_publisher is loaded first because the robot_state_publisher listens to the
+        sensor_msgs/JointState topic which is published by the joint_state_publisher
+    -->
+    <node
+        name="joint_state_publisher"
+        pkg="joint_state_publisher"
+        type="joint_state_publisher"/>
+
+    <!--
+        Second publish the robot state. The robot_state_publisher (see: http://wiki.ros.org/robot_state_publisher)
+        picks up the robot description (provided by scuttle_description and scuttle_model) from the
+        parameter server via the `robot_description` parameter.
+    -->
+    <node
+        name="robot_state_publisher"
+        pkg="robot_state_publisher"
+        type="robot_state_publisher"/>
+
+    <!--
+        We don't include the SLAM node here because gmapping puts out a lot of logs to the console that can't be
+        silenced. So instead we run that as a stand-alone node. That way gmapping won't polute the navigation logs
+    -->
+
+    <include file="$(find scuttle_navigation)/launch/scuttle_navigation.launch">
+        <arg name="map_file" value="$(find scuttle_navigation)/maps/map.yaml"/>
+        <arg name="move_forward_only" value="false"/>
+        <arg name="is_physical" value="$(arg is_physical)"/>
+    </include>
 </launch>

--- a/launch/base.launch
+++ b/launch/base.launch
@@ -75,11 +75,24 @@
         messages. It then selects the most appropriate Twist command to actually send to the
         driver.
     -->
-    <include file="$(find twist_mux)/launch/twist_mux.launch">
-        <arg name="cmd_vel_out" value="cmd_vel"/>
-        <arg name="config_locks"  value="$(find scuttle_model)/config/twist_mux_locks.yaml"/>
-        <arg name="config_topics" value="$(find scuttle_model)/config/twist_mux_topics.yaml"/>
-    </include>
+    <!--
+        We should really load the twist_mux launch file, but that tries to load a joystick_relay
+        node written in python, which is broken and hasn't been fixed since 2020.
+        See: https://github.com/ros-teleop/twist_mux/issues/22
+
+        So we avoid using the launch file and just load the nodes manually.
+    -->
+    <node pkg="twist_mux" type="twist_mux" name="twist_mux" output="screen">
+        <remap from="cmd_vel_out" to="cmd_vel"/>
+
+        <rosparam file="$(find scuttle_model)/config/twist_mux_locks.yaml"  command="load"/>
+        <rosparam file="$(find scuttle_model)/config/twist_mux_topics.yaml" command="load"/>
+    </node>
+
+    <node pkg="twist_mux" type="twist_marker" name="twist_marker">
+        <remap from="twist"  to="cmd_vel"/>
+        <remap from="marker" to="twist_marker"/>
+    </node>
 
     <!--
         Load the custom nodes.

--- a/launch/base.launch
+++ b/launch/base.launch
@@ -14,15 +14,14 @@
         name="robot_description"
         command="$(find xacro)/xacro $(find scuttle_model)/urdf/scuttle.xacro" />
 
+    <!--
+        Figure out if we're running virtual or real world and set the 'use_sim_time' parameter.
+    -->
     <group unless="$(arg is_physical)">
         <param name ="/use_sim_time" value="true"/>
-
-        <!-- Don't need a lidar here because the gazebo files already have that included -->
     </group>
-
     <group if="$(arg is_physical)">
         <param name ="/use_sim_time" value="false"/>
-        <node name="scuttle_driver" pkg="scuttle_driver" type="scuttle_driver.py" output="screen"/>
     </group>
 
     <!--
@@ -51,20 +50,33 @@
         type="robot_state_publisher"/>
 
     <!--
-        Start the custom nodes
-    -->
-    <include file="$(find scuttle_model)/launch/scuttle_model.launch">
-        <arg name="is_physical" value="$(arg is_physical)"/>
-    </include>
-
-    <!--
         We don't include the SLAM node here because gmapping puts out a lot of logs to the console that can't be
         silenced. So instead we run that as a stand-alone node. That way gmapping won't polute the navigation logs
     -->
 
+    <!--
+        Load scuttle_driver and navigation before loading the custom nodes so that the custom
+        nodes can override the parameters for scuttle_driver and the navigation nodes.
+    -->
+    <group if="$(arg is_physical)">
+        <include file="$(find scuttle_driver)/launch/scuttle_driver.launch">
+            <arg name="is_physical" value="$(arg is_physical)"/>
+        </include>
+    </group>
+
     <include file="$(find scuttle_navigation)/launch/scuttle_navigation.launch">
         <arg name="map_file" value="$(find scuttle_navigation)/maps/map.yaml"/>
         <arg name="move_forward_only" value="false"/>
+        <arg name="is_physical" value="$(arg is_physical)"/>
+    </include>
+
+    <!--
+        Load the custom nodes.
+
+        By loading the custom nodes last they have a chance of overriding the parameter settings
+        for all the other nodes (see: http://wiki.ros.org/roslaunch/XML#Evaluation_order)
+    -->
+    <include file="$(find scuttle_model)/launch/scuttle_model.launch">
         <arg name="is_physical" value="$(arg is_physical)"/>
     </include>
 </launch>

--- a/launch/base.launch
+++ b/launch/base.launch
@@ -51,6 +51,13 @@
         type="robot_state_publisher"/>
 
     <!--
+        Start the custom nodes
+    -->
+    <include file="$(find scuttle_model)/launch/scuttle_model.launch">
+        <arg name="is_physical" value="$(arg is_physical)"/>
+    </include>
+
+    <!--
         We don't include the SLAM node here because gmapping puts out a lot of logs to the console that can't be
         silenced. So instead we run that as a stand-alone node. That way gmapping won't polute the navigation logs
     -->

--- a/launch/base.launch
+++ b/launch/base.launch
@@ -6,10 +6,13 @@
     <!--
         Publish the robot model to the parameter server so that other nodes can determine what
         the different joints of the robot are.
+
+        The robot model comes from 'scuttle_model' which pulls the default scuttle parts from
+        'scuttle_description' and allows users to add their own parts.
     -->
     <param
         name="robot_description"
-        command="$(find xacro)/xacro $(find scuttle_description)/urdf/scuttle.xacro" />
+        command="$(find xacro)/xacro $(find scuttle_model)/urdf/scuttle.xacro" />
 
     <group unless="$(arg is_physical)">
         <param name ="/use_sim_time" value="true"/>

--- a/launch/base.launch
+++ b/launch/base.launch
@@ -71,6 +71,17 @@
     </include>
 
     <!--
+        Load the Twist multiplexer. This node takes multiple topics, each of which contains Twist
+        messages. It then selects the most appropriate Twist command to actually send to the
+        driver.
+    -->
+    <include file="$(find twist_mux)/launch/twist_mux.launch">
+        <arg name="cmd_vel_out" value="cmd_vel"/>
+        <arg name="config_locks"  value="$(find scuttle_model)/config/twist_mux_locks.yaml"/>
+        <arg name="config_topics" value="$(find scuttle_model)/config/twist_mux_topics.yaml"/>
+    </include>
+
+    <!--
         Load the custom nodes.
 
         By loading the custom nodes last they have a chance of overriding the parameter settings

--- a/launch/scuttle_bringup.launch
+++ b/launch/scuttle_bringup.launch
@@ -1,7 +1,7 @@
 <launch>
-	<arg name="is_physical" default="true"/>
+    <arg name="is_physical" default="true"/>
 
-	<include file="$(find scuttle_bringup)/launch/base.launch" >
-		<arg name="is_physical" value="$(arg is_physical)"/>
-	</include>
+    <include file="$(find scuttle_bringup)/launch/base.launch" >
+        <arg name="is_physical" value="$(arg is_physical)"/>
+    </include>
 </launch>

--- a/launch/scuttle_bringup_daemon.launch
+++ b/launch/scuttle_bringup_daemon.launch
@@ -1,21 +1,23 @@
 <launch>
-	<arg name="is_physical" default="true"/>
+    <arg name="is_physical" default="true"/>
 
-	<group if="$(arg is_physical)">
-		<include file="$(find teleop_twist_joy)/launch/teleop.launch"></include>
-	</group>
+    <group if="$(arg is_physical)">
+        <include file="$(find teleop_twist_joy)/launch/teleop.launch">
+            <arg name="cmd_vel_topic" default="joy_vel" />
+        </include>
+    </group>
 
-	<include file="$(find scuttle_bringup)/launch/base.launch" >
-		<arg name="is_physical" value="$(arg is_physical)"/>
-	</include>
+    <include file="$(find scuttle_bringup)/launch/base.launch" >
+        <arg name="is_physical" value="$(arg is_physical)"/>
+    </include>
 
-	<!--
-		This assumes we have something writing to the /scan topic, e.g. a LIDAR or something.
-		Without it gmapping will not start.
-	-->
-	<!--
-	<include file="$(find scuttle_slam)/launch/scuttle_slam.launch">
-		<arg name="slam_methods" value="gmapping"/>
-  	</include>
-	-->
+    <!--
+        This assumes we have something writing to the /scan topic, e.g. a LIDAR or something.
+        Without it gmapping will not start.
+    -->
+    <!--
+    <include file="$(find scuttle_slam)/launch/scuttle_slam.launch">
+        <arg name="slam_methods" value="gmapping"/>
+      </include>
+    -->
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -12,16 +12,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>scuttle_description</build_depend>
+  <build_depend>scuttle_model</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
 
-  <build_export_depend>scuttle_description</build_export_depend>
+  <build_export_depend>scuttle_model</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
 
-  <exec_depend>scuttle_description</exec_depend>
+  <exec_depend>scuttle_model</exec_depend>
+  <exec_depend>scuttle_driver</exec_depend>
   <exec_depend>scuttle_navigation</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -11,13 +11,17 @@
   <url type="website">https://scuttlerobot.org/</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+
   <build_depend>scuttle_description</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
+
   <build_export_depend>scuttle_description</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
+
   <exec_depend>scuttle_description</exec_depend>
+  <exec_depend>scuttle_navigation</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
 


### PR DESCRIPTION
This PR is part of the addition of scuttle_model (see https://github.com/scuttlerobot/scuttle_model/pull/2). This PR moves the joint_state_publisher and the robot_state_publisher nodes from the scuttlerobot/scuttle_gazebo#3 repository so that these nodes are provided both when running with Gazebo and on a physical SCUTTLE robot.

The link order of the packages is:

scuttle_gazebo -> scuttle_bringup -> joint_state_publisher
-> robot_state_publisher
-> scuttle_model (scuttle.xacro)
-> scuttle_driver
-> scuttle_navigation
-> twist_mux (http://wiki.ros.org/twist_mux)
-> scuttle_model -> scuttle_description